### PR TITLE
Added HttpClient and Url properties

### DIFF
--- a/HttpMoq.Tests/Api/ReceivedDeleteRequestTests.cs
+++ b/HttpMoq.Tests/Api/ReceivedDeleteRequestTests.cs
@@ -16,15 +16,14 @@ namespace HttpMoq.Tests.Api
 
         public async Task InitializeAsync()
         {
-            _api = new MockApi(23499);
+            _api = new MockApi();
             _request = _api.Delete("/test?foo=bar")
                 .ReturnJson(new { foo = "bar" })
                 .SetStatusCode(HttpStatusCode.BadRequest);
 
             await _api.StartAsync();
-
-            using var client = new HttpClient();
-            _response = await client.DeleteAsync("http://localhost:23499/test?foo=bar");
+            
+            _response = await _api.HttpClient.DeleteAsync("/test?foo=bar");
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq.Tests/Api/ReceivedGetRequestTests.cs
+++ b/HttpMoq.Tests/Api/ReceivedGetRequestTests.cs
@@ -16,15 +16,14 @@ namespace HttpMoq.Tests.Api
 
         public async Task InitializeAsync()
         {
-            _api = new MockApi(23496);
+            _api = new MockApi();
             _request = _api.Get("/test?foo=bar")
                 .ReturnJson(new { foo = "bar" })
                 .SetStatusCode(HttpStatusCode.BadRequest);
 
             await _api.StartAsync();
-
-            using var client = new HttpClient();
-            _response = await client.GetAsync("http://localhost:23496/test?foo=bar");
+            
+            _response = await _api.HttpClient.GetAsync("/test?foo=bar");
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq.Tests/Api/ReceivedPatchRequestTests.cs
+++ b/HttpMoq.Tests/Api/ReceivedPatchRequestTests.cs
@@ -14,14 +14,13 @@ namespace HttpMoq.Tests.Api
 
         public async Task InitializeAsync()
         {
-            _api = new MockApi(5487);
+            _api = new MockApi();
             _request = _api.Patch("/test")
                 .ReturnJson(new { foo = "bar" });
 
             await _api.StartAsync();
-
-            using var client = new HttpClient();
-            _response = await client.PatchAsync("http://localhost:5487/test", null);
+            
+            _response = await _api.HttpClient.PatchAsync("test", null);
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq.Tests/Api/ReceivedPostRequestTests.cs
+++ b/HttpMoq.Tests/Api/ReceivedPostRequestTests.cs
@@ -23,7 +23,7 @@ namespace HttpMoq.Tests.Api
             await _api.StartAsync();
 
             using var client = new HttpClient();
-            _response = await client.PostAsync("http://localhost:34944/test", null);
+            _response = await client.PostAsync($"{_api.Url}/test", null);
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq.Tests/Api/ReceivedPutRequestTests.cs
+++ b/HttpMoq.Tests/Api/ReceivedPutRequestTests.cs
@@ -19,9 +19,8 @@ namespace HttpMoq.Tests.Api
                 .ReturnJson(new { foo = "bar" });
 
             await _api.StartAsync();
-
-            using var client = new HttpClient();
-            _response = await client.PutAsync("http://localhost:5467/test", null);
+            
+            _response = await _api.HttpClient.PutAsync("/test", null);
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq.Tests/Api/ReceivedUnmockedRequestTests.cs
+++ b/HttpMoq.Tests/Api/ReceivedUnmockedRequestTests.cs
@@ -15,9 +15,8 @@ namespace HttpMoq.Tests.Api
             _api = new MockApi(46345);
 
             await _api.StartAsync();
-
-            using var client = new HttpClient();
-            _response = await client.GetAsync("http://localhost:46345/test");
+            
+            _response = await _api.HttpClient.GetAsync("/test");
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq.Tests/Api/WhereRequestLimitIsExceededTests.cs
+++ b/HttpMoq.Tests/Api/WhereRequestLimitIsExceededTests.cs
@@ -23,10 +23,9 @@ namespace HttpMoq.Tests.Api
                 .SetLimit(1);
 
             await _api.StartAsync();
-
-            using var client = new HttpClient();
-            _response1 = await client.GetAsync("http://localhost:23437/test");
-            _response2 = await client.GetAsync("http://localhost:23437/test");
+            
+            _response1 = await _api.HttpClient.GetAsync("/test");
+            _response2 = await _api.HttpClient.GetAsync("/test");
         }
 
         public async Task DisposeAsync()

--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <LangVersion>latestMajor</LangVersion>
-    <Version>0.9.0</Version>
+    <Version>0.10.0</Version>
     <Authors>Reece Russell</Authors>
     <Description>A super small, super simple library used to mock API responses in integration tests. With support for xUnit and NUnit.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
- Added an empty constructor which automatically finds a free port, instead of a user having to define one.
- Added a `HttpClient` property which can be used to hit the `MockApi`. Alongside this, there is now a `Url` property with the URL of the `MockApi` - this is `BaseUrl` for the `HttpClient`.

Closes: #14 