### PR TITLE
Fix an issue where responses are cut off

### DIFF
--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -12,6 +12,7 @@
     <RepositoryType>git</RepositoryType>
     <PackageTags>tdd, bdd, tests, xunit, nunit, msbuild</PackageTags>
     <PackageReleaseNotes>Added new functionality to limit the number of times a Request can be used.</PackageReleaseNotes>
+    <OutputType>Library</OutputType>
   </PropertyGroup>
 
   <ItemGroup>

--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <LangVersion>latestMajor</LangVersion>
-    <Version>0.11.0</Version>
+    <Version>0.11.1</Version>
     <Authors>Reece Russell</Authors>
     <Description>A super small, super simple library used to mock API responses in integration tests. With support for xUnit and NUnit.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/HttpMoq/MockApi.cs
+++ b/HttpMoq/MockApi.cs
@@ -164,6 +164,8 @@ namespace HttpMoq
         {
             _output.Enqueue("Incoming request to: " + context.Request.GetDisplayUrl());
 
+            context.Response.Headers.Add("Date", DateTimeOffset.UtcNow.ToString());
+
             var request = Find(context.Request.Path.Value, context.Request.QueryString.Value, context.Request.Method);
             if (request == null)
             {


### PR DESCRIPTION
There's an issue with the hosting packages where they do not work with `Microsoft.Extensions.Configuration` v5.x.x+. The work around this is to specify the `Date` header before starting the response.