### PR TITLE
resolve request detection issues in `MockApi.Find()` method

### DIFF
--- a/HttpMoq.Tests/MockApiTests.cs
+++ b/HttpMoq.Tests/MockApiTests.cs
@@ -46,6 +46,33 @@ namespace HttpMoq.Tests
 
             api.Find("/test", null, "GET").Should().Be(request);
         }
+        
+        [Fact]
+        public void Find_GivenMultipleRequestsWithSamePathButDifferentQueryParams_ReturnsTheExpectedRequest()
+        {
+            var api = new MockApi(9000);
+            api.Get("/test");
+            api.Get("/test?hello=hello");
+            api.Get("/test?world=hello");
+            api.Get("/test/world?hello=world");
+            var request = api.Get("/test?hello=world");
+
+            api.Find("/test", "?hello=world", "GET").Should().Be(request);
+        }
+        
+        [Fact]
+        public void Find_GivenMultipleRequestsWithTheSameFirstUriSegment_ReturnsTheExpectedRequest()
+        {
+            var api = new MockApi(9010);
+            api.Get("/test");
+            api.Get("/test/hello");
+            api.Get("/test/world/hello");
+            api.Get("/test/world?test=world");
+            api.Get("/hello/test/world");
+            var request = api.Get("/test/world");
+
+            api.Find("/test/world", null, "GET").Should().Be(request);
+        }
 
         [Fact]
         public void Expect_GivenValidMethodAndString_AddsRequestToApi()

--- a/HttpMoq.Tests/PathHelperTests.cs
+++ b/HttpMoq.Tests/PathHelperTests.cs
@@ -25,5 +25,16 @@ namespace HttpMoq.Tests
         {
             PathHelper.IsMatch(pattern, path).Should().BeTrue();
         }
+        
+        [Theory]
+        [InlineData("/", "/hello")]
+        [InlineData("/hello", "/hello/world")]
+        [InlineData("/hello/*", "/hello")]
+        [InlineData("/hello/world", "/hello/world/test")]
+        [InlineData("/hello/*/world", "/hello/*/world/test")]
+        public void IsMatch_GivenPatternAndDifferentPath_ReturnsFalse(string pattern, string path)
+        {
+            PathHelper.IsMatch(pattern, path).Should().BeFalse();
+        }
     }
 }

--- a/HttpMoq.Tests/QueryStringHelperTests.cs
+++ b/HttpMoq.Tests/QueryStringHelperTests.cs
@@ -23,6 +23,13 @@ namespace HttpMoq.Tests
             var result = QueryStringHelper.Parse(string.Empty);
             result.Count.Should().Be(0);
         }
+        
+        [Fact]
+        public void Parse_GivenNullQueryString_ReturnsEmptyResults()
+        {
+            var result = QueryStringHelper.Parse(null);
+            result.Count.Should().Be(0);
+        }
 
         [Fact]
         public void IsMatch_GivenValidPatternAndQueryString_ReturnsTrue()

--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
     <LangVersion>latestMajor</LangVersion>
-    <Version>0.11.1</Version>
+    <Version>0.11.2</Version>
     <Authors>Reece Russell</Authors>
     <Description>A super small, super simple library used to mock API responses in integration tests. With support for xUnit and NUnit.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/HttpMoq/MockApi.cs
+++ b/HttpMoq/MockApi.cs
@@ -94,10 +94,10 @@ namespace HttpMoq
 
         internal Request Find(string path, string queryString, string method)
         {
-            return _requests.FirstOrDefault(x => PathHelper.IsMatch(x.Path, path) &&
+            return _requests.FirstOrDefault(x => PathHelper.IsMatch(path, x.Path) &&
                                                  x.Method == method &&
                                                  (x.Limit == null || x.Count < x.Limit) &&
-                                                 (x.Query == null || QueryStringHelper.IsMatch(x.Query, queryString)));
+                                                 QueryStringHelper.IsMatch(x.Query, queryString));
         }
 
         public void Remove(Request request)

--- a/HttpMoq/PathHelper.cs
+++ b/HttpMoq/PathHelper.cs
@@ -49,7 +49,7 @@ namespace HttpMoq
 
             pattern = pattern.Replace("*", "(.*[^/])");
 
-            return Regex.IsMatch(path, pattern);
+            return Regex.IsMatch(path, $"^{pattern}$");
         }
     }
 }

--- a/HttpMoq/QueryStringHelper.cs
+++ b/HttpMoq/QueryStringHelper.cs
@@ -9,12 +9,7 @@ namespace HttpMoq
         {
             var args = new Dictionary<string, string[]>();
 
-            if (queryString == null)
-            {
-                return args;
-            }
-
-            if (queryString.Length < 1)
+            if (queryString == null || queryString.Length < 1)
             {
                 return args;
             }

--- a/HttpMoq/QueryStringHelper.cs
+++ b/HttpMoq/QueryStringHelper.cs
@@ -9,6 +9,11 @@ namespace HttpMoq
         {
             var args = new Dictionary<string, string[]>();
 
+            if (queryString == null)
+            {
+                return args;
+            }
+
             if (queryString.Length < 1)
             {
                 return args;


### PR DESCRIPTION
Noticed a couple of issues with regards to detecting the correct requests when they have similar paths set:

#### QueryString Issue

Using the below example:

```
var api = new MockApi(5000);
var requestA = api.Get("/a");
var requestB = api.Get("/a?b=c");
```

If you were to call the `MockApi.Find()` method with the `queryString` parameter set to `?b=c` - the first request (`requestA`) would be the one returned, even though it does not match the query string specified.

This is because of the check [here](https://github.com/reecerussell/http-moq/blob/master/HttpMoq/MockApi.cs#L100), which will return true in `requestA`'s case as there are no query parameters set, and because this is the first request submitted it will be the one returned by `FirstOrDefault()`. This checked should be removed to ensure that the `QueryStringHelper.IsMatch()` method is called for every request like [this](https://github.com/dcolesDEV/http-moq/blob/resolve-find-issues/HttpMoq/MockApi.cs#L100).

#### Path Issue

Using the below example:

```
var api = new MockApi(5000);
var requestA = api.Get("/a");
var requestB = api.Get("/a/b/c");
var requestC = api.Get("/a/b");
```

If you were to call the `MockApi.Find()` method with the `path` parameter set to `/a/b` - the first request (`requestA`) would be the one returned, even though it does not match the full path specified.

This is because the `pattern` parameter for the `PathHelper.IsMatch()` method is being set to the path of the request being checked [here](https://github.com/reecerussell/http-moq/blob/master/HttpMoq/MockApi.cs#L97), so when [this](https://github.com/reecerussell/http-moq/blob/2ddd1095acf67d58e41fbb4529e7b42eaf9b5251/HttpMoq/PathHelper.cs#L52) regex check occurs for `requestA`, it will be checking whether `/a` matches the RegEx pattern `/a` rather than `a/b` and as a result return `true`. Instead, this should actually be set to the `path`parameter specified in the `MockApi.Find()` method call like [this](https://github.com/dcolesDEV/http-moq/blob/resolve-find-issues/HttpMoq/MockApi.cs#L97), as this is the pattern that is attempting to be detected within this call.

However, even if this is corrected - there is still an oustanding issue with regards to the RegEx check that will cause `requestB` to be returned, when `requestC` is expected. This is because `a/b/c` still matches the RegEx pattern of `a/b`. Adding `^` to the start and `$` to the end of the RegEx pattern [here](https://github.com/dcolesDEV/http-moq/blob/resolve-find-issues/HttpMoq/PathHelper.cs#L52) will resolve this, as it will then ensure that the string is an exact match.

I've added some additional tests cases to validate these changes are behaving as expected, and are not impacting any existing functionality.