### PR TITLE
Only support .net standard

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -29,11 +29,6 @@ jobs:
         with:
           dotnet-version: '3.1.x'
 
-      - name: Setup .NET (5.x)
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: '5.x'
-
       - name: Restore
         run: |
           dotnet restore HttpMoq/HttpMoq.csproj
@@ -44,11 +39,6 @@ jobs:
 
       - name: Unit Test
         run: dotnet test --no-restore -c Release /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura HttpMoq.Tests/HttpMoq.Tests.csproj
-
-      - name: Upload Coverage to Codecov (net5.0)
-        uses: codecov/codecov-action@v1
-        with:
-          file: HttpMoq.Tests/coverage.net5.0.cobertura.xml
 
       - name: Upload Coverage to Codecov (netcoreapp3.1)
         uses: codecov/codecov-action@v1
@@ -80,7 +70,7 @@ jobs:
       - name: Setup .NET
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '5.x'
+          dotnet-version: '3.1.x'
 
       - name: Publish
         run: dotnet nuget push packages/**.nupkg --api-key ${{secrets.NUGET_API_KEY}} --source https://www.nuget.org/api/v2/package --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ bin
 obj
 *.user
 *cobertura.xml
+.idea

--- a/HttpMoq.Tests/HttpMoq.Tests.csproj
+++ b/HttpMoq.Tests/HttpMoq.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net5.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
     <Version>0.11.2</Version>
     <Authors>Reece Russell</Authors>

--- a/HttpMoq/MockApi.cs
+++ b/HttpMoq/MockApi.cs
@@ -17,8 +17,8 @@ namespace HttpMoq
     public sealed class MockApi : IDisposable
     {
         private readonly IWebHost _host;
-        private readonly List<Request> _requests = new();
-        private Queue<string> _output = new();
+        private readonly List<Request> _requests = new List<Request>();
+        private Queue<string> _output = new Queue<string>();
 
         public string Url { get; }
         public HttpClient HttpClient { get; }


### PR DESCRIPTION
As .netstandard is supported in .net5, there's no need to support both.