### PR TITLE
Update `MockApi` to expose the port via a readonly property

### DIFF
--- a/HttpMoq.Tests/MockApiTests.cs
+++ b/HttpMoq.Tests/MockApiTests.cs
@@ -86,5 +86,13 @@ namespace HttpMoq.Tests
 
             api.Find(path, null, method).Should().Be(request);
         }
+
+        [Fact]
+        public void Ctor_GivenPort_SetsPortAndUrl()
+        {
+            var api = new MockApi(8080);
+            api.Port.Should().Be(8080);
+            api.Url.Should().Be("http://localhost:8080");
+        }
     }
 }

--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
-    <Version>0.11.2</Version>
+    <Version>0.12.0</Version>
     <Authors>Reece Russell</Authors>
     <Description>A super small, super simple library used to mock API responses in integration tests. With support for xUnit and NUnit.</Description>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/HttpMoq/MockApi.cs
+++ b/HttpMoq/MockApi.cs
@@ -21,6 +21,7 @@ namespace HttpMoq
         private Queue<string> _output = new Queue<string>();
 
         public string Url { get; }
+        public int Port { get; }
         public HttpClient HttpClient { get; }
 
         public MockApi() : this(FindFreePort())
@@ -29,6 +30,7 @@ namespace HttpMoq
 
         public MockApi(int port)
         {
+            Port = port;
             Url = $"http://localhost:{port}";
             HttpClient = new HttpClient
             {


### PR DESCRIPTION
I've updated the constructor to set a new `Port` property on the `MockApi` class.