### PR TITLE
Add header validation

### DIFF
--- a/HttpMoq/HttpMoq.csproj
+++ b/HttpMoq/HttpMoq.csproj
@@ -13,6 +13,7 @@
     <PackageTags>tdd, bdd, tests, xunit, nunit, msbuild</PackageTags>
     <PackageReleaseNotes>Added new functionality to limit the number of times a Request can be used.</PackageReleaseNotes>
     <OutputType>Library</OutputType>
+    <PackageVersion>0.13.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I've added more functionality to validate request's headers. This is useful to validate say a `HTTP-Signature` in a test case, to ensure it's being set correctly.